### PR TITLE
use cryptography, not Math.random

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,9 +47,12 @@ function generatePassword() {
 }
 
 function generateRandomPassword(characters, length) {
+    const randomValues = new Uint32Array(length);
+    crypto.getRandomValues(randomValues);
+
     let password = '';
     for (let i = 0; i < length; i++) {
-        const randomIndex = Math.floor(Math.random() * characters.length);
+        const randomIndex = randomValues[i] % characters.length;
         password += characters.charAt(randomIndex);
     }
     return password;


### PR DESCRIPTION
`Math.random()` is not secure so should *not* be used for passwords. The `crypto` module, which is baked in to most browsers (https://caniuse.com/cryptography), is much more secure than `Math.random()` and cannot be guessed easily as `Math.random()`.

https://whereisthebug.com/never-use-math-random-for-passwords/